### PR TITLE
Upgrade to latest Netlify Build

### DIFF
--- a/index.js
+++ b/index.js
@@ -1,95 +1,22 @@
 /* Generates a sitemap */
-const fs = require('fs')
-const path = require('path')
-const mkdirp = require('mkdirp')
-const sm = require('sitemap')
-const globby = require('globby')
+const makeSiteMap = require('./make_sitemap')
 
 module.exports = {
-  name: '@netlify/plugin-sitemap',
-  onPostBuild: async ({ constants, pluginConfig, netlifyConfig }) => {
-    const baseUrl = pluginConfig.baseUrl || process.env.URL
-    const buildConfig = netlifyConfig.build || {}
+  onPostBuild: async ({ constants, inputs, utils }) => {
+    const baseUrl = inputs.baseUrl || process.env.URL
     // Backwards compat... Correct opt is buildDir
-    const buildDistOpt = pluginConfig.dir || pluginConfig.distPath || pluginConfig.buildDir
-    const buildDir = buildDistOpt || buildConfig.publish || constants.BUILD_DIR
-    const excludeFiles = pluginConfig.exclude || []
+    const buildDir = inputs.dir || inputs.distPath || inputs.buildDir || constants.PUBLISH_DIR
 
-    if (!buildDir) {
-      throw new Error('Sitemap plugin missing build directory value')
-    }
-    if (!baseUrl) {
-      throw new Error('Sitemap plugin missing homepage value')
-    }
     console.log('Creating sitemap from files...')
 
     const data = await makeSitemap({
       homepage: baseUrl,
       distPath: buildDir,
-      exclude: excludeFiles,
-      prettyURLs: pluginConfig.prettyURLs
+      exclude: inputs.exclude,
+      prettyURLs: inputs.prettyURLs,
+      failPlugin: utils.build.failPlugin,
     })
 
     console.log('Sitemap Built!', data.sitemapFile)
   },
 }
-
-async function makeSitemap(opts = {}) {
-  const { distPath, fileName, homepage, exclude, prettyURLs } = opts
-  // eslint-disable-next-line
-  const prettyUrlsEnabled = (prettyURLs === false || prettyURLs === 'false') ? false : true
-  if (!distPath) {
-    throw new Error('Missing distPath option')
-  }
-  const htmlFiles = `${distPath}/**/**.html`
-  const excludeFiles = (exclude || []).map((filePath) => {
-    return `!${filePath.replace(/^!/, '')}`
-  })
-
-  const lookup = [ htmlFiles ].concat(excludeFiles)
-  const paths = await globby(lookup)
-  const urls = paths.map(file => {
-    const regex = new RegExp(`^${distPath}`)
-    let urlPath = file.replace(regex, '')
-    if (prettyUrlsEnabled) {
-      urlPath = urlPath.replace(/\/index\.html$/, '').replace(/\.html$/, '')
-    }
-
-    return {
-      url: urlPath,
-      changefreq: 'weekly',
-      priority: 0.8,
-      lastmodrealtime: true,
-      lastmodfile: file,
-    }
-  })
-  const options = {
-    hostname: `${homepage.replace(/\/$/, '')}/`,
-    cacheTime: 600000, // 600 sec cache period
-    urls,
-  }
-  // Creates a sitemap object given the input configuration with URLs
-  const sitemap = sm.createSitemap(options)
-  // Generates XML with a callback function
-  sitemap.toXML(error => {
-    if (error) {
-      throw error
-    }
-  })
-  // Gives you a string containing the XML data
-  const xml = sitemap.toString()
-  // write sitemap to file
-  const sitemapFileName = fileName || 'sitemap.xml'
-  const sitemapFile = path.resolve(distPath, sitemapFileName)
-  // Ensure dist path
-  await mkdirp(distPath)
-  // Write sitemap
-  fs.writeFileSync(sitemapFile, xml, 'utf-8')
-  // Return info
-  return {
-    sitemapPath: sitemapFileName,
-    sitemap: sitemap
-  }
-}
-
-module.exports.makeSitemap = makeSitemap

--- a/make_sitemap.js
+++ b/make_sitemap.js
@@ -1,0 +1,57 @@
+const fs = require('fs')
+const util = require('util')
+const path = require('path')
+const mkdirp = require('mkdirp')
+const sm = require('sitemap')
+const globby = require('globby')
+
+module.exports = async function makeSitemap(opts = {}) {
+  const { distPath, fileName, homepage, exclude, prettyURLs, failPlugin } = opts
+  const htmlFiles = `${distPath}/**/**.html`
+  const excludeFiles = (exclude || []).map((filePath) => {
+    return `!${filePath.replace(/^!/, '')}`
+  })
+
+  const lookup = [ htmlFiles ].concat(excludeFiles)
+  const paths = await globby(lookup)
+  const urls = paths.map(file => {
+    let urlPath = file.startsWith(distPath) ? file.replace(distPath, '') : distPath
+    if (prettyURLs) {
+      urlPath = urlPath.replace(/\/index\.html$/, '').replace(/\.html$/, '')
+    }
+    return {
+      url: urlPath,
+      changefreq: 'weekly',
+      priority: 0.8,
+      lastmodrealtime: true,
+      lastmodfile: file,
+    }
+  })
+  const options = {
+    hostname: `${homepage.replace(/\/$/, '')}/`,
+    cacheTime: 600000, // 600 sec cache period
+    urls,
+  }
+  // Creates a sitemap object given the input configuration with URLs
+  const sitemap = sm.createSitemap(options)
+  // Generates XML
+  try {
+    await util.promisify(sitemap.toXML.bind(sitemap))()
+  } catch (error) {
+    failBuild('Could not generate XML sitemap', { error })
+  }
+  // Gives you a string containing the XML data
+  const xml = sitemap.toString()
+  // write sitemap to file
+  const sitemapFileName = fileName || 'sitemap.xml'
+  const sitemapFile = path.resolve(distPath, sitemapFileName)
+  // Ensure dist path
+  await mkdirp(distPath)
+  // Write sitemap
+  await util.promisify(fs.writeFile)(sitemapFile, xml)
+  // Return info
+  return {
+    sitemapPath: sitemapFileName,
+    sitemap: sitemap
+  }
+}

--- a/manifest.yml
+++ b/manifest.yml
@@ -1,0 +1,12 @@
+name: netlify-plugin-sitemap
+inputs:
+  - name: baseUrl
+    # description: Site's home URL. Defaults to Netlify's SITE URL.
+  - name: buildDir
+    # description: Publish directory. Defaults to Netlify's publish directory.
+  - name: exclude
+    # description: Excluded files.
+    default: []
+  - name: prettyURLs
+    # description: Enable pretty URLS
+    default: true

--- a/package.json
+++ b/package.json
@@ -23,6 +23,10 @@
     "README.md"
   ],
   "author": "David Wells",
+  "repository": "https://github.com/netlify-labs/netlify-plugin-sitemap",
+  "bugs": {
+    "url": "https://github.com/netlify-labs/netlify-plugin-sitemap/issues"
+  },
   "license": "MIT",
   "dependencies": {
     "globby": "^10.0.1",

--- a/tests/sitemap.test.js
+++ b/tests/sitemap.test.js
@@ -2,7 +2,7 @@ import fs from 'fs'
 import path from 'path'
 import test from 'ava'
 import rimraf from 'rimraf'
-import { makeSitemap } from '../'
+import makeSitemap from '../make_sitemap.js'
 import { parseString } from 'xml2js'
 
 const BUILDPATH = path.resolve(__dirname, './fixtures')
@@ -20,6 +20,8 @@ test.serial('Creates Sitemap with all html files', async (t) => {
     sitemapData = await makeSitemap({
       homepage: 'https://site.com/',
       distPath: BUILDPATH,
+      prettyURLs: true,
+      failPlugin() {},
     })
     xmlData = await parseXml(SITEMAP_OUTPUT)
   } catch (err) {
@@ -46,7 +48,8 @@ test.serial('Sitemap pretty urls off works correctly', async (t) => {
     sitemapData = await makeSitemap({
       homepage: 'https://site.com/',
       distPath: BUILDPATH,
-      prettyURLs: false
+      prettyURLs: false,
+      failPlugin() {},
     })
     xmlData = await parseXml(SITEMAP_OUTPUT)
   } catch (err) {
@@ -74,12 +77,14 @@ test.serial('Sitemap exclude works correctly', async (t) => {
     sitemapData = await makeSitemap({
       homepage: 'https://site.com/',
       distPath: BUILDPATH,
+      prettyURLs: true,
       exclude: [
         // Path
         EXCLUDE_PATH,
         // Glob pattern
         '**/**/child-one.html'
-      ]
+      ],
+      failPlugin() {},
     })
     xmlData = await parseXml(path.resolve(BUILDPATH, 'sitemap.xml'))
   } catch (err) {


### PR DESCRIPTION
Thanks a lot for creating this Build plugin!

Netlify just released the latest version of Build plugins. Build plugins are currently enabled in the Netlify website for a small percentage of beta users.

This PR upgrades this plugin to the latest API. You can find the new documentation [here](https://github.com/netlify/build/blob/master/README.md). Changes include:
  - add a `repository` field in `package.json`
  - add a `bugs` field in `package.json`
  - add a `manifest.yml`
  - `pluginConfig` was renamed to `inputs`
  - `constants.BUILD_DIR` was renamed to `constants.PUBLISH_DIR`. `netlifyConfig.build.publish` is automatically included in `constants.PUBLISH_DIR`.
  - `plugin.name` was removed
  - two errors were being thrown when `inputs` were missing. However since those `inputs` have default values, those branches cannot be reached.
  - the publish directory was used to build a new RegExp(`^${distPath}`). However this does not work when the publish directory contains regular expression characters since those are not escaped. This PR fixes this.
  - use promises instead of synchronous or callbacks
  - errors should be reported using `utils.build.failPlugin()` instead of throwing
  - `fs.writeFile()` default encoding is `utf-8`
  
I have done some quick tests, but you might want to manually [test this PR](https://github.com/netlify/build/blob/master/README.md#using-a-local-plugin) as well just to make sure :)