### PR TITLE
Fix absolute `input` `buildDir`

### DIFF
--- a/index.js
+++ b/index.js
@@ -1,3 +1,5 @@
+const { join } = require('path')
+
 /* Generates a sitemap */
 const makeSitemap = require('./make_sitemap')
 
@@ -5,7 +7,7 @@ module.exports = {
   onPostBuild: async ({ constants, inputs, utils }) => {
     const baseUrl = inputs.baseUrl || process.env.URL
     // Backwards compat... Correct opt is buildDir
-    const buildDir = inputs.dir || inputs.distPath || inputs.buildDir || constants.PUBLISH_DIR
+    const buildDir = join(process.cwd(), inputs.dir || inputs.distPath || inputs.buildDir || constants.PUBLISH_DIR)
 
     console.log('Creating sitemap from files...')
 


### PR DESCRIPTION
Some users are experiencing the [following error](app.bugsnag.com/netlify/netlify-build/errors/5eaf2db3e00704001dac4e6b):

```
EACCES: permission denied, mkdir '/web' 
```

This happens when users are passing an absolute path to the `buildDir` input. That input should always be treated as a path relative to the base directory. This PR fixes this.