### PR TITLE
Option to add missing trailing slash to prettyURLs

### DIFF
--- a/README.md
+++ b/README.md
@@ -56,3 +56,16 @@ package = "@netlify/plugin-sitemap"
   # disable pretty URLS and keep `index.html` & trailing `.html` file references in paths
   prettyURLs = false
 ```
+
+When using pretty URLs, missing trailing slashes can be appended by setting the `trailingSlash` option to `true`. This renders `site.com/page-one.html` as `site.com/page-one/`.
+
+```toml
+[[plugins]]
+package = "@netlify/plugin-sitemap"
+
+  [plugins.inputs]
+  buildDir = "public"
+  prettyURLs = true
+  # Append missing trailing slash to pretty URL
+  trailingSlash = true
+```

--- a/index.js
+++ b/index.js
@@ -16,6 +16,7 @@ module.exports = {
       distPath: buildDir,
       exclude: inputs.exclude,
       prettyURLs: inputs.prettyURLs,
+      trailingSlash: inputs.trailingSlash,
       failBuild: utils.build.failBuild,
     })
 

--- a/make_sitemap.js
+++ b/make_sitemap.js
@@ -6,7 +6,7 @@ const sm = require('sitemap')
 const globby = require('globby')
 
 module.exports = async function makeSitemap(opts = {}) {
-  const { distPath, fileName, homepage, exclude, prettyURLs, failBuild } = opts
+  const { distPath, fileName, homepage, exclude, prettyURLs, trailingSlash, failBuild } = opts
   const htmlFiles = `${distPath}/**/**.html`
   const excludeFiles = (exclude || []).map((filePath) => {
     return `!${filePath.replace(/^!/, '')}`
@@ -18,6 +18,10 @@ module.exports = async function makeSitemap(opts = {}) {
     let urlPath = file.startsWith(distPath) ? file.replace(distPath, '') : distPath
     if (prettyURLs) {
       urlPath = urlPath.replace(/\/index\.html$/, '').replace(/\.html$/, '')
+
+      if (trailingSlash) {
+        urlPath += urlPath.endsWith("/") ? "" : "/";
+      }
     }
     return {
       url: urlPath,

--- a/tests/sitemap.test.js
+++ b/tests/sitemap.test.js
@@ -41,6 +41,35 @@ test.serial('Creates Sitemap with all html files', async (t) => {
   ])
 })
 
+test.serial("Creates Sitemap with all html files with trailing slash", async t => {
+  let xmlData;
+  let sitemapData = {};
+  try {
+    sitemapData = await makeSitemap({
+      homepage: "https://site.com/",
+      distPath: BUILDPATH,
+      prettyURLs: true,
+      trailingSlash: true,
+      failBuild() {},
+    });
+    xmlData = await parseXml(SITEMAP_OUTPUT);
+  } catch (err) {
+    console.log(err);
+  }
+  const pages = getPages(xmlData);
+  t.truthy(sitemapData.sitemapPath);
+  t.deepEqual(pages, [
+    "https://site.com/",
+    "https://site.com/page-one/",
+    "https://site.com/page-three/",
+    "https://site.com/page-two/",
+    "https://site.com/children/child-one/",
+    "https://site.com/children/child-two/",
+    "https://site.com/children/grandchildren/grandchild-one/",
+    "https://site.com/children/grandchildren/grandchild-two/",
+  ]);
+});
+
 test.serial('Sitemap pretty urls off works correctly', async (t) => {
   let xmlData
   let sitemapData = {}


### PR DESCRIPTION
When generating sitemap, URLs are currently rendered without trailing slash, whereas Netlify default 301 redirects to URLs with trailing slash.

This PR adds the option to add missing trailing slash if prettyURLs are used. 