### PR TITLE
📕 Docs: update info on prettyURLs option

### DIFF
--- a/README.md
+++ b/README.md
@@ -43,9 +43,9 @@ package = "@netlify/plugin-sitemap"
 
 ### Pretty URLs
 
-Pretty urls a.k.a. `site.com/index.html` being turned into  `site.com/` is on by default.
+Pretty urls a.k.a. `site.com/index.html` being turned into  `site.com/` is off by default.
 
-To disable this feature set the `prettyURLs` option to `false`
+To enable this feature set the `prettyURLs` option to `true`
 
 ```toml
 [[plugins]]
@@ -53,6 +53,6 @@ package = "@netlify/plugin-sitemap"
 
   [plugins.inputs]
   buildDir = "public"
-  # disable pretty URLS and keep `index.html` & trailing `.html` file references in paths
-  prettyURLs = false
+  # enable pretty URLS and remove `index.html` & trailing `.html` file references in paths
+  prettyURLs = true
 ```


### PR DESCRIPTION
This PR updates the README to reflect the logic for the `prettyURLs` option. 

Addresses #12 

Currently, the logic in https://github.com/netlify-labs/netlify-plugin-sitemap/blob/master/make_sitemap.js#L19 checks if the value is present. Unless the user passes in a `true` value, it will not work.

I'm happy to revise this PR to update the script's logic to provide a `true` default value rather than changing the README, if the intent is to have it on by default (as it's currently documented in the README 🙂)