### PR TITLE
Fix `files` field in `package.json`

### DIFF
--- a/package.json
+++ b/package.json
@@ -19,6 +19,7 @@
   "files": [
     "index.js",
     "make_sitemap.js",
+    "manifest.yml",
     "package.json",
     "package-lock.json",
     "README.md"


### PR DESCRIPTION
The `files` field in `package.json` is missing `manifest.yml`. As a result, this plugin makes builds fail when loaded.