### PR TITLE
Fix `failBuild` wrong variable name

### DIFF
--- a/index.js
+++ b/index.js
@@ -14,7 +14,7 @@ module.exports = {
       distPath: buildDir,
       exclude: inputs.exclude,
       prettyURLs: inputs.prettyURLs,
-      failPlugin: utils.build.failPlugin,
+      failBuild: utils.build.failBuild,
     })
 
     console.log('Sitemap Built!', data.sitemapPath)

--- a/make_sitemap.js
+++ b/make_sitemap.js
@@ -6,7 +6,7 @@ const sm = require('sitemap')
 const globby = require('globby')
 
 module.exports = async function makeSitemap(opts = {}) {
-  const { distPath, fileName, homepage, exclude, prettyURLs, failPlugin } = opts
+  const { distPath, fileName, homepage, exclude, prettyURLs, failBuild } = opts
   const htmlFiles = `${distPath}/**/**.html`
   const excludeFiles = (exclude || []).map((filePath) => {
     return `!${filePath.replace(/^!/, '')}`

--- a/tests/sitemap.test.js
+++ b/tests/sitemap.test.js
@@ -21,7 +21,7 @@ test.serial('Creates Sitemap with all html files', async (t) => {
       homepage: 'https://site.com/',
       distPath: BUILDPATH,
       prettyURLs: true,
-      failPlugin() {},
+      failBuild() {},
     })
     xmlData = await parseXml(SITEMAP_OUTPUT)
   } catch (err) {
@@ -49,7 +49,7 @@ test.serial('Sitemap pretty urls off works correctly', async (t) => {
       homepage: 'https://site.com/',
       distPath: BUILDPATH,
       prettyURLs: false,
-      failPlugin() {},
+      failBuild() {},
     })
     xmlData = await parseXml(SITEMAP_OUTPUT)
   } catch (err) {
@@ -84,7 +84,7 @@ test.serial('Sitemap exclude works correctly', async (t) => {
         // Glob pattern
         '**/**/child-one.html'
       ],
-      failPlugin() {},
+      failBuild() {},
     })
     xmlData = await parseXml(path.resolve(BUILDPATH, 'sitemap.xml'))
   } catch (err) {


### PR DESCRIPTION
A reference to `failBuild` leads to an undefined variable error due to wrong variable name. [Bugsnag error](https://app.bugsnag.com/netlify/netlify-build/errors/5ed509102ffca20018cc3aac).

This PR fixes this.