### PR TITLE
fix: add missing manifest entry for trailingSlash

### DIFF
--- a/manifest.yml
+++ b/manifest.yml
@@ -11,5 +11,5 @@ inputs:
     # description: Enable pretty URLS
     default: true
   - name: trailingSlash
-    # Append missing trailing slash to pretty URL
+    # Append trailing slash to pretty URL
     default: false

--- a/manifest.yml
+++ b/manifest.yml
@@ -10,3 +10,6 @@ inputs:
   - name: prettyURLs
     # description: Enable pretty URLS
     default: true
+  - name: trailingSlash
+    # Append missing trailing slash to pretty URL
+    default: true

--- a/manifest.yml
+++ b/manifest.yml
@@ -12,4 +12,4 @@ inputs:
     default: true
   - name: trailingSlash
     # Append missing trailing slash to pretty URL
-    default: true
+    default: false


### PR DESCRIPTION
Follow up on https://github.com/netlify-labs/netlify-plugin-sitemap/pull/13