### PR TITLE
fix(exclude): revert absolute path value for buildDir

### DIFF
--- a/index.js
+++ b/index.js
@@ -6,12 +6,14 @@ module.exports = {
     const baseUrl = inputs.baseUrl || process.env.URL
     // Backwards compat... Correct opt is buildDir
     const buildDir = inputs.dir || inputs.distPath || inputs.buildDir || constants.PUBLISH_DIR
+    // remove leading / to treat the dir a a relative one
+    const trimmedBuildDir = buildDir.startsWith('/') ? buildDir.slice(1) : buildDir
 
     console.log('Creating sitemap from files...')
 
     const data = await makeSitemap({
       homepage: baseUrl,
-      distPath: buildDir,
+      distPath: trimmedBuildDir,
       exclude: inputs.exclude,
       prettyURLs: inputs.prettyURLs,
       changeFreq: inputs.changeFreq,

--- a/index.js
+++ b/index.js
@@ -1,5 +1,3 @@
-const { join } = require('path')
-
 /* Generates a sitemap */
 const makeSitemap = require('./make_sitemap')
 
@@ -7,7 +5,7 @@ module.exports = {
   onPostBuild: async ({ constants, inputs, utils }) => {
     const baseUrl = inputs.baseUrl || process.env.URL
     // Backwards compat... Correct opt is buildDir
-    const buildDir = join(process.cwd(), inputs.dir || inputs.distPath || inputs.buildDir || constants.PUBLISH_DIR)
+    const buildDir = inputs.dir || inputs.distPath || inputs.buildDir || constants.PUBLISH_DIR
 
     console.log('Creating sitemap from files...')
 


### PR DESCRIPTION
Fixes https://github.com/netlify-labs/netlify-plugin-sitemap/issues/28
Reverts https://github.com/netlify-labs/netlify-plugin-sitemap/pull/11 in favour of trimming a forward slash if exists.
We can re-visit #11 after we release a fix with excludes in mind.