### PR TITLE
allow `filePath` input

### DIFF
--- a/index.js
+++ b/index.js
@@ -12,6 +12,7 @@ module.exports = {
     console.log('Creating sitemap from files...')
 
     const data = await makeSitemap({
+      fileName: inputs.filePath,
       homepage: baseUrl,
       distPath: trimmedBuildDir,
       exclude: inputs.exclude,

--- a/manifest.yml
+++ b/manifest.yml
@@ -4,6 +4,8 @@ inputs:
     # description: Site's home URL. Defaults to Netlify's SITE URL.
   - name: buildDir
     # description: Publish directory. Defaults to Netlify's publish directory.
+  - name: filePath
+    # description: Output path, relative to publish directory. Default: sitemap.xml
   - name: exclude
     # description: Excluded files.
     default: []


### PR DESCRIPTION
This PR supports the use-case where a site is being built to a subdirectory: while HTML file paths should be evaluated from the root of the build, the actual `sitemap.xml` file should be placed in the subdirectory, since in such cases the root directory of the deploy site will be inaccessible and probably already has a sitemap. 

This enables a `filePath` input parameter, passed to the sitemap library's `fileName` parameter. it defaults to `sitemap.xml` if not passed, but allows intervention for the case described above, if needed