### PR TITLE
fix: support buildDir = '.'

### DIFF
--- a/make_sitemap.js
+++ b/make_sitemap.js
@@ -17,13 +17,20 @@ const getPaths = async ({ distPath, exclude, cwd }) => {
   return paths
 }
 
-const getUrlFromFile = ({ file, distPath, prettyURLs, trailingSlash }) => {
-  const url = file.startsWith(distPath) ? file.replace(distPath, '') : distPath
-
-  if (!prettyURLs) {
-    return url
+const normalizeFile = ({ file, distPath }) => {
+  // handle root distPath
+  if (distPath === '.') {
+    return `/${file}`
   }
 
+  if (file.startsWith(distPath)) {
+    return file.replace(distPath, '')
+  }
+
+  return distPath
+}
+
+const prettifyUrl = ({ url, trailingSlash }) => {
   const prettyUrl = url.replace(/\/index\.html$/, '').replace(/\.html$/, '')
 
   if (!trailingSlash) {
@@ -31,6 +38,17 @@ const getUrlFromFile = ({ file, distPath, prettyURLs, trailingSlash }) => {
   }
 
   return ensureTrailingSlash(prettyUrl)
+}
+
+const getUrlFromFile = ({ file, distPath, prettyURLs, trailingSlash }) => {
+  const url = normalizeFile({ file, distPath })
+
+  if (!prettyURLs) {
+    return url
+  }
+
+  const prettyUrl = prettifyUrl({ url, trailingSlash })
+  return prettyUrl
 }
 
 const getUrlsFromPaths = ({ paths, distPath, prettyURLs, trailingSlash, changeFreq, priority, cwd }) => {

--- a/tests/sitemap.test.js
+++ b/tests/sitemap.test.js
@@ -22,12 +22,27 @@ test.afterEach(async (t) => {
 
 // Test relative and absolute paths
 const CONFIGS = [
-  { distPath: './fixtures', testNamePostfix: 'relative path', cwd: __dirname },
-  { distPath: path.resolve(__dirname, './fixtures'), testNamePostfix: 'absolute path' },
+  {
+    distPath: './fixtures',
+    testNamePostfix: 'relative path',
+    cwd: __dirname,
+    excludePath: './fixtures/children/grandchildren/grandchild-two.html',
+  },
+  {
+    distPath: path.resolve(__dirname, './fixtures'),
+    testNamePostfix: 'absolute path',
+    excludePath: path.resolve(__dirname, './fixtures/children/grandchildren/grandchild-two.html'),
+  },
+  {
+    distPath: '.',
+    testNamePostfix: 'root relative path',
+    cwd: path.join(__dirname, 'fixtures'),
+    excludePath: './children/grandchildren/grandchild-two.html',
+  },
 ]
 
 // eslint-disable-next-line max-lines-per-function
-CONFIGS.forEach(({ distPath, testNamePostfix, cwd }) => {
+CONFIGS.forEach(({ distPath, testNamePostfix, cwd, excludePath }) => {
   test(`Creates Sitemap with all html files - ${testNamePostfix}`, async (t) => {
     const { fileName } = t.context
     const sitemapData = await makeSitemap({
@@ -143,8 +158,6 @@ CONFIGS.forEach(({ distPath, testNamePostfix, cwd }) => {
 
   test(`Sitemap exclude works correctly - ${testNamePostfix}`, async (t) => {
     const { fileName } = t.context
-    const toExclude = './fixtures/children/grandchildren/grandchild-two.html'
-    const excludePath = cwd === undefined ? path.resolve(__dirname, toExclude) : toExclude
     const sitemapData = await makeSitemap({
       homepage: 'https://site.com/',
       distPath,


### PR DESCRIPTION
Fixes https://github.com/netlify-labs/netlify-plugin-sitemap/issues/34 and also adds tests for it