### PR TITLE
fix: handle buildDir = /

### DIFF
--- a/index.js
+++ b/index.js
@@ -3,12 +3,14 @@ const { env } = require('process')
 
 const makeSitemap = require('./make_sitemap')
 
+const getInputsDir = ({ inputs }) => inputs.dir || inputs.distPath || inputs.buildDir
+
 const getBuildDir = ({ inputs, constants }) => {
   // Backwards compat... Correct opt is buildDir
-  const buildDir = inputs.dir || inputs.distPath || inputs.buildDir || constants.PUBLISH_DIR
+  const buildDir = getInputsDir({ inputs }) || constants.PUBLISH_DIR
   // remove leading / to treat the dir a a relative one
   const trimmedBuildDir = buildDir.startsWith('/') ? buildDir.slice(1) : buildDir
-  return trimmedBuildDir
+  return trimmedBuildDir || '.'
 }
 
 module.exports = {


### PR DESCRIPTION
Fixes https://github.com/netlify-labs/netlify-plugin-sitemap/issues/33

Requires https://github.com/netlify-labs/netlify-plugin-sitemap/pull/41 to work

Setting `buildDir = /` would have resulted in trying to glob on `/**/**.html` which can't be accessed.