### PR TITLE
feat: add url prefix

### DIFF
--- a/README.md
+++ b/README.md
@@ -102,7 +102,6 @@ package = "@netlify/plugin-sitemap"
   changeFreq = "daily"
   priority = 0.5
 ```
-
 ### Set base URL from environment variable rather than plugin input
 
 You can include an environment variable (`NETLIFY_PLUGIN_SITEMAP_BASEURL`) in your Netlify site to set the base URL that will be used by the plugin. This option is useful if the `baseUrl` plugin input can't be used.
@@ -110,3 +109,27 @@ Example use case: different Netlify sites built from the same repository and don
 
 Priority of base URL assignment:
 plugin input `baseUrl` -> env `NETLIFY_PLUGIN_SITEMAP_BASEURL` -> Netlify site default URL
+
+```toml
+[[plugins]]
+package = "@netlify/plugin-sitemap"
+
+  [plugins.inputs]
+  baseUrl = "http://example.com"
+```
+
+> NOTE: Although the above is called base URL this actually ends up being the hostname in the sitemap and as such trying to use a URL like `http://example.com/en/` will results in `http://example.com/`
+
+### Add a prefix to the URL
+
+You can include an environment variable (NETLIFY_PLUGIN_SITEMAP_URL_PREFIX) in your Netlify site to set the URL prefix that will be used by the plugin. This option is useful if the urlPrefix plugin input can't be used. Example use case: different Netlify sites built from the same repository and don't/can't have custom domains.
+
+Priority of base URL assignment: plugin input urlPrefix -> env NETLIFY_PLUGIN_SITEMAP_URL_PREFIX
+
+```toml
+[[plugins]]
+package = "@netlify/plugin-sitemap"
+
+  [plugins.inputs]
+  urlPrefix = "/en/"
+```

--- a/README.md
+++ b/README.md
@@ -118,7 +118,7 @@ package = "@netlify/plugin-sitemap"
   baseUrl = "http://example.com"
 ```
 
-> NOTE: Although the above is called base URL this actually ends up being the hostname in the sitemap and as such trying to use a URL like `http://example.com/en/` will results in `http://example.com/`
+>  NOTE: Although the above is called base URL this actually ends up being the hostname in the sitemap and as such trying to use a URL like `http://example.com/en/` will results in `http://example.com/`
 
 ### Add a prefix to the URL
 

--- a/index.js
+++ b/index.js
@@ -20,7 +20,7 @@ const getBuildDir = ({ inputs, constants }) => {
 module.exports = {
   onPostBuild: async ({ constants, inputs, utils }) => {
     const baseUrl = inputs.baseUrl || env.NETLIFY_PLUGIN_SITEMAP_BASEURL || env.URL
-    const urlPrefix = inputs.urlPrefix || env.NETLIFY_PLUGIN_SITEMAP_URL_PREFIX
+    const urlPrefix = inputs.urlPrefix || env.NETLIFY_PLUGIN_SITEMAP_URL_PREFIX || null
     const buildDir = getBuildDir({ inputs, constants })
 
     console.log('Creating sitemap from files...')

--- a/index.js
+++ b/index.js
@@ -20,6 +20,7 @@ const getBuildDir = ({ inputs, constants }) => {
 module.exports = {
   onPostBuild: async ({ constants, inputs, utils }) => {
     const baseUrl = inputs.baseUrl || env.NETLIFY_PLUGIN_SITEMAP_BASEURL || env.URL
+    const urlPrefix = inputs.urlPrefix || env.NETLIFY_PLUGIN_SITEMAP_URL_PREFIX
     const buildDir = getBuildDir({ inputs, constants })
 
     console.log('Creating sitemap from files...')
@@ -34,6 +35,7 @@ module.exports = {
       priority: inputs.priority,
       trailingSlash: inputs.trailingSlash,
       failBuild: utils.build.failBuild,
+      urlPrefix,
     })
 
     console.log('Sitemap Built!', data.sitemapPath)

--- a/make_sitemap.js
+++ b/make_sitemap.js
@@ -49,8 +49,9 @@ const getUrlFromFile = ({ file, distPath, prettyURLs, trailingSlash }) => {
 const getUrlsFromPaths = ({ paths, distPath, prettyURLs, trailingSlash, changeFreq, priority, cwd, urlPrefix }) => {
   const urls = paths.map((file) => {
     const url = getUrlFromFile({ file, distPath, prettyURLs, trailingSlash })
+
     return {
-      url: urlPrefix + url,
+      url: urlPrefix ? urlPrefix + url : url,
       changefreq: changeFreq,
       priority,
       lastmodrealtime: true,

--- a/make_sitemap.js
+++ b/make_sitemap.js
@@ -51,7 +51,7 @@ const getUrlsFromPaths = ({ paths, distPath, prettyURLs, trailingSlash, changeFr
     const url = getUrlFromFile({ file, distPath, prettyURLs, trailingSlash })
 
     return {
-      url: urlPrefix ? urlPrefix + url : url,
+      url: (urlPrefix ? urlPrefix + url : url).replace('//', '/'),
       changefreq: changeFreq,
       priority,
       lastmodrealtime: true,

--- a/make_sitemap.js
+++ b/make_sitemap.js
@@ -46,11 +46,11 @@ const getUrlFromFile = ({ file, distPath, prettyURLs, trailingSlash }) => {
   return prettyUrl
 }
 
-const getUrlsFromPaths = ({ paths, distPath, prettyURLs, trailingSlash, changeFreq, priority, cwd }) => {
+const getUrlsFromPaths = ({ paths, distPath, prettyURLs, trailingSlash, changeFreq, priority, cwd, urlPrefix }) => {
   const urls = paths.map((file) => {
     const url = getUrlFromFile({ file, distPath, prettyURLs, trailingSlash })
     return {
-      url,
+      url: urlPrefix + url,
       changefreq: changeFreq,
       priority,
       lastmodrealtime: true,
@@ -83,6 +83,7 @@ module.exports = async function makeSitemap(opts = {}) {
     distPath,
     fileName,
     homepage,
+    urlPrefix,
     exclude,
     prettyURLs,
     trailingSlash,
@@ -93,7 +94,7 @@ module.exports = async function makeSitemap(opts = {}) {
   } = opts
 
   const paths = await getPaths({ distPath, exclude, cwd })
-  const urls = getUrlsFromPaths({ paths, distPath, prettyURLs, trailingSlash, changeFreq, priority, cwd })
+  const urls = getUrlsFromPaths({ paths, distPath, prettyURLs, trailingSlash, changeFreq, priority, cwd, urlPrefix })
 
   const { sitemap, xml } = await createSitemapInfo({ homepage, urls, failBuild })
 

--- a/manifest.yml
+++ b/manifest.yml
@@ -21,3 +21,6 @@ inputs:
   - name: trailingSlash
     # Append trailing slash to pretty URL
     default: false
+  - name: urlPrefix
+    # Prefix the url with a value such as /en/
+    default: null

--- a/tests/sitemap.test.js
+++ b/tests/sitemap.test.js
@@ -177,6 +177,7 @@ CONFIGS.forEach(({ distPath, testNamePostfix, cwd, excludePath }) => {
     const xmlData = await parseXml(fileName)
     const pages = getPages(xmlData)
     t.truthy(sitemapData.sitemapPath)
+
     t.deepEqual(pages, [
       'https://site.com/',
       'https://site.com/page-one',
@@ -186,6 +187,32 @@ CONFIGS.forEach(({ distPath, testNamePostfix, cwd, excludePath }) => {
       'https://site.com/children/child-two',
       'https://site.com/children/grandchildren/grandchild-one',
       // excluded 'https://site.com/children/grandchildren/grandchild-two.html'
+    ])
+  })
+
+  test(`Sitemap urlPrefix works correctly - ${testNamePostfix}`, async (t) => {
+    const { fileName } = t.context
+    const sitemapData = await makeSitemap({
+      homepage: 'https://site.com/',
+      distPath,
+      prettyURLs: true,
+      urlPrefix: 'en/',
+      failBuild() {},
+      fileName,
+      cwd,
+    })
+    const xmlData = await parseXml(fileName)
+    const pages = getPages(xmlData)
+    t.truthy(sitemapData.sitemapPath)
+    t.deepEqual(pages, [
+      'https://site.com/en/',
+      'https://site.com/en/page-one',
+      'https://site.com/en/page-three',
+      'https://site.com/en/page-two',
+      'https://site.com/en/children/child-one',
+      'https://site.com/en/children/child-two',
+      'https://site.com/en/children/grandchildren/grandchild-one',
+      'https://site.com/en/children/grandchildren/grandchild-two',
     ])
   })
 })


### PR DESCRIPTION
We needed to be able to append a locality to the URL's with the way the sitemap module currently works we were unable to do this we tried to use `NETLIFY_PLUGIN_SITEMAP_BASEURL` and add a URL like `http://example.com/en/` but this won't work as the sitemap module is passed this URL as hostname so will strip the path away.

To solve this a new options has been added which allows you to pass in a `urlPrefix` this will be appended to the URL, you can either use the plugin input `urlPrefix` or set the environment variable `NETLIFY_PLUGIN_SITEMAP_URL_PREFIX` 
