### PR TITLE
fix: don't fail in publish directory is root

### DIFF
--- a/make_sitemap.js
+++ b/make_sitemap.js
@@ -9,7 +9,8 @@ const { createSitemap } = require('sitemap')
 const ensureTrailingSlash = (url) => (url.endsWith('/') ? url : `${url}/`)
 
 const getPaths = async ({ distPath, exclude = [], cwd = '.' }) => {
-  const htmlFiles = `${getRelPath(distPath, cwd)}/**/**.html`
+  const relPath = getRelPath(distPath, cwd)
+  const htmlFiles = relPath === '' ? '**/**.html' : `${relPath}/**/**.html`
   const excludeFiles = exclude.map((excludedPath) => `!${getRelPath(excludedPath, cwd).replace(/^!/, '')}`)
 
   const lookup = [htmlFiles, ...excludeFiles]


### PR DESCRIPTION
Fixes https://github.com/netlify-labs/netlify-plugin-sitemap/issues/71

Reproduces on https://github.com/erezrokah/netlify-plugin-sitemap-site with a publish directory not set.

I'll open another issue to figure out how to better test this scenario