### PR TITLE
chore: use GitHub app token

### DIFF
--- a/.github/workflows/release-please.yml
+++ b/.github/workflows/release-please.yml
@@ -7,8 +7,13 @@ jobs:
   release-please:
     runs-on: ubuntu-latest
     steps:
+      - uses: navikt/github-app-token-generator@2d70c12368d1958155af4d283f9f21c9a2a8cb98
+        id: get-token
+        with:
+          private-key: ${{ secrets.PRIVATE_KEY }}
+          app-id: ${{ secrets.APP_ID }}
       - uses: GoogleCloudPlatform/release-please-action@v2
         with:
-          token: ${{ secrets.GITHUB_TOKEN }}
+          token: ${{ steps.get-token.outputs.token }}
           release-type: node
           package-name: '@netlify/plugin-sitemap'


### PR DESCRIPTION
So `release-please` PRs trigger GitHub workflows.

> I'm not using https://github.com/tibdex/github-app-token since it's very hard to know what's the action is doing since the code is [complied](https://github.com/tibdex/github-app-token/blob/v1.3.0/dist/index.js) from TypeScript. I feel it's safer to pin to a commit hash of `navikt/github-app-token-generator`