### PR TITLE
feat: support custom URLs to be added to the Sitemap

### DIFF
--- a/README.md
+++ b/README.md
@@ -133,3 +133,14 @@ package = "@netlify/plugin-sitemap"
   [plugins.inputs]
   urlPrefix = "/en/"
 ```
+### Add custom URLs to the Sitemap
+
+You can include custom URLs to be added to the sitemap by passing an array of custom URLs.
+
+```toml
+[[plugins]]
+package = "@netlify/plugin-sitemap"
+
+  [plugins.inputs]
+  customUrls = ["/news", "/about"]
+```

--- a/index.js
+++ b/index.js
@@ -36,6 +36,7 @@ module.exports = {
       trailingSlash: inputs.trailingSlash,
       failBuild: utils.build.failBuild,
       urlPrefix,
+      customUrls: inputs.customUrls,
     })
 
     console.log('Sitemap Built!', data.sitemapPath)

--- a/make_sitemap.js
+++ b/make_sitemap.js
@@ -47,7 +47,17 @@ const getUrlFromFile = ({ file, distPath, prettyURLs, trailingSlash }) => {
   return prettyUrl
 }
 
-const getUrlsFromPaths = ({ paths, distPath, prettyURLs, trailingSlash, changeFreq, priority, cwd, urlPrefix }) => {
+const getUrlsFromPaths = ({
+  paths,
+  distPath,
+  prettyURLs,
+  trailingSlash,
+  changeFreq,
+  priority,
+  cwd,
+  urlPrefix,
+  customUrls,
+}) => {
   const urls = paths.map((file) => {
     const url = getUrlFromFile({ file, distPath, prettyURLs, trailingSlash })
 
@@ -58,6 +68,16 @@ const getUrlsFromPaths = ({ paths, distPath, prettyURLs, trailingSlash, changeFr
       lastmodrealtime: true,
       lastmodfile: cwd === undefined ? file : path.resolve(cwd, file),
     }
+  })
+  customUrls.forEach((customUrl) => {
+    const url = {
+      url: (urlPrefix ? urlPrefix + customUrl : customUrl).replace('//', '/'),
+      changefreq: changeFreq,
+      priority,
+      lastmodrealtime: true,
+    }
+    // eslint-disable-next-line fp/no-mutating-methods
+    urls.push(url)
   })
   return urls
 }
@@ -93,10 +113,21 @@ module.exports = async function makeSitemap(opts = {}) {
     cwd,
     changeFreq = DEFAULT_CHANGE_FREQ,
     priority = DEFAULT_PRIORITY,
+    customUrls = [],
   } = opts
 
   const paths = await getPaths({ distPath, exclude, cwd })
-  const urls = getUrlsFromPaths({ paths, distPath, prettyURLs, trailingSlash, changeFreq, priority, cwd, urlPrefix })
+  const urls = getUrlsFromPaths({
+    paths,
+    distPath,
+    prettyURLs,
+    trailingSlash,
+    changeFreq,
+    priority,
+    cwd,
+    urlPrefix,
+    customUrls,
+  })
 
   const { sitemap, xml } = await createSitemapInfo({ homepage, urls, failBuild })
 

--- a/tests/sitemap.test.js
+++ b/tests/sitemap.test.js
@@ -215,6 +215,35 @@ CONFIGS.forEach(({ distPath, testNamePostfix, cwd, excludePath }) => {
       'https://site.com/en/children/grandchildren/grandchild-two',
     ])
   })
+
+  test(`Generate Sitemap with custom URLs - ${testNamePostfix}`, async (t) => {
+    const { fileName } = t.context
+    const sitemapData = await makeSitemap({
+      homepage: 'https://site.com/',
+      distPath,
+      prettyURLs: true,
+      urlPrefix: 'en/',
+      failBuild() {},
+      fileName,
+      cwd,
+      customUrls: ['/news', '/about'],
+    })
+    const xmlData = await parseXml(fileName)
+    const pages = getPages(xmlData)
+    t.truthy(sitemapData.sitemapPath)
+    t.deepEqual(pages, [
+      'https://site.com/en/',
+      'https://site.com/en/page-one',
+      'https://site.com/en/page-three',
+      'https://site.com/en/page-two',
+      'https://site.com/en/children/child-one',
+      'https://site.com/en/children/child-two',
+      'https://site.com/en/children/grandchildren/grandchild-one',
+      'https://site.com/en/children/grandchildren/grandchild-two',
+      'https://site.com/en/news',
+      'https://site.com/en/about',
+    ])
+  })
 })
 
 const getPages = (data) => data.urlset.url.map((record) => record.loc[0])


### PR DESCRIPTION
## Summary

Add support to define custom URLs to be used when generating the Sitemap.

I came across this useful plugin, but it doesn't work for Single Page Applications (SPA.) I thought it would be great to support adding custom URLs to the Sitemap via the plugin.

I think these changes will partly solve https://github.com/netlify-labs/netlify-plugin-sitemap/issues/8. Though these changes don't crawl the page, nor try to guess the routes used for the SPA, I think the solution is useful for developers looking for a simple way of adding a few URLs to their sitemap.

I'll put the PR in draft to begin with, because I want to get your opinions of my suggestion. I'm also not sure about what `lastmodfile` is used for, so I just omitted it when generating the customURLs. 

